### PR TITLE
JIRA 6393: FastAPI endpoint for the `subset()` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ docker compose -f docker/compose.yaml build --no-cache
 docker compose -f docker/compose.yaml up
 ```
 This should spin up the API services
-```
 
 
 ### Development

--- a/src/icefabric_api/README.md
+++ b/src/icefabric_api/README.md
@@ -1,5 +1,102 @@
-CSV files for catchment specific values are too big to be checked in.  They are stored here:  s3://ngwpc-dev/DanielCumpton/divide_csv.tgz  
-Download and untar in the icefabric/src/icefabric_api/data directory.  
-For now, you can run modules by listing them in the module list defined on line 108 in run_modules.py.  Text files showing all parameters as key/value  
-pairs will be written to a files per catchment.  A JSON is output to the terminal.  SFT, SMP, and LASAM csv files still need work to define the parameters properly.  
+# Icefabric API
+
+FastAPI service providing access to hydrology and water resources data stored in Apache Iceberg format.
+
+## Features
+
+- **Streamflow Observations** - USGS hourly streamflow data in CSV/Parquet formats
+- **Hydrofabric Subsets** - Upstream watershed data as downloadable geopackages
+- **Interactive Documentation** - Built-in Swagger UI and ReDoc
+
+## Quick Start
+
+### Prerequisites
+
+- [uv](https://docs.astral.sh/uv/) package manager
+
+### Installation
+
+```bash
+# Clone repository
+git clone <repository-url>
+cd icefabric
+
+# Install package in development mode
+uv pip install src/icefabric_api -e .
+```
+
+### Running the API
+
+```bash
+# Start development server
+cd src/icefabric_api
+python -m app.main
+```
+
+The API will be available at `http://localhost:8000`
+
+### Docker Alternative
+
+```bash
+# Build and run with Docker
+docker compose -f docker/compose.yaml build --no-cache
+docker compose -f docker/compose.yaml up
+```
+
+## API Endpoints
+
+### Streamflow Observations
+
+- `GET /v1/streamflow_observations/sources` - List available data sources
+- `GET /v1/streamflow_observations/usgs/available` - Get available station IDs
+- `GET /v1/streamflow_observations/usgs/{identifier}/info` - Station metadata
+- `GET /v1/streamflow_observations/usgs/csv` - Download CSV data
+- `GET /v1/streamflow_observations/usgs/parquet` - Download Parquet data
+
+### Hydrofabric
+
+- `GET /v1/hydrofabric/{identifier}/gpkg` - Download watershed subset as geopackage
+
+### Health Check
+
+- `HEAD /health` - API health status
+
+## Usage Examples
+
+### Download Streamflow Data
+
+```python
+import requests
+import pandas as pd
+
+# Get station information
+response = requests.get(
+    "http://localhost:8000/v1/streamflow_observations/usgs/01031500/info"
+)
+station_info = response.json()
+
+# Download CSV data
+csv_response = requests.get(
+    "http://localhost:8000/v1/streamflow_observations/usgs/csv",
+    params={
+        "identifier": "01031500",
+        "start_date": "2023-01-01T00:00:00",
+        "end_date": "2023-01-31T23:59:59"
+    }
+)
+df = pd.read_csv(csv_response.text)
+```
+
+## Documentation
+
+- **Interactive API Docs**: http://localhost:8000/docs
+- **Alternative Docs**: http://localhost:8000/redoc
+- **OpenAPI Schema**: http://localhost:8000/openapi.json
+
+## Initial Parameters
+
+CSV files for catchment specific values are too big to be checked in.  They are stored here:  s3://ngwpc-dev/DanielCumpton/divide_csv.tgz
+Download and untar in the icefabric/src/icefabric_api/data directory.
+For now, you can run modules by listing them in the module list defined on line 108 in run_modules.py.  Text files showing all parameters as key/value
+pairs will be written to a files per catchment.  A JSON is output to the terminal.  SFT, SMP, and LASAM csv files still need work to define the parameters properly.
 See icefabric/src/icefabric_api/data/modules.csv for module name strings.

--- a/src/icefabric_api/app/main.py
+++ b/src/icefabric_api/app/main.py
@@ -2,6 +2,7 @@ import uvicorn
 from fastapi import FastAPI, status
 from pydantic import BaseModel
 
+from app.routers.hydrofabric.router import api_router as hydrofabric_api_router
 from app.routers.streamflow_observations.router import api_router as streamflow_api_router
 
 app = FastAPI(
@@ -20,6 +21,7 @@ class HealthCheck(BaseModel):
 
 
 # Include routers
+app.include_router(hydrofabric_api_router, prefix="/v1")
 app.include_router(streamflow_api_router, prefix="/v1")
 
 

--- a/src/icefabric_api/app/routers/hydrofabric/conftest.py
+++ b/src/icefabric_api/app/routers/hydrofabric/conftest.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+import pytest
+
+sample_gauges = [
+    "01010000",
+    "02450825",
+    "03173000",
+    "04100500",
+    "05473450",
+    "06823500",
+    "07060710",
+    "08070000",
+    "09253000",
+    "10316500",
+    "11456000",
+    "12411000",
+    "13337000",
+    "14020000",
+]
+
+
+@pytest.fixture(params=sample_gauges)
+def gauge_hf_uri(request) -> str:
+    """Returns individual gauge identifiers for parameterized testing"""
+    return request.param
+
+
+@pytest.fixture
+def testing_dir() -> Path:
+    """Returns the testing data dir"""
+    return Path(__file__).parents[4] / "icefabric_tools/tests/data/"

--- a/src/icefabric_api/app/routers/hydrofabric/router.py
+++ b/src/icefabric_api/app/routers/hydrofabric/router.py
@@ -1,0 +1,76 @@
+import pathlib
+import tempfile
+import uuid
+
+from fastapi import APIRouter, HTTPException, Path
+from fastapi.responses import FileResponse
+from pyiceberg.catalog import load_catalog
+from starlette.background import BackgroundTask
+
+from icefabric_tools import IdType, subset
+
+api_router = APIRouter(prefix="/hydrofabric")
+
+catalog_settings: dict = {
+    "type": "sql",
+    "uri": "sqlite:////tmp/warehouse/pyiceberg_catalog.db",
+    "warehouse": "file:///tmp/warehouse",
+}
+
+
+@api_router.get("/{identifier}/gpkg")
+async def get_hydrofabric_subset_gpkg(
+    identifier: str = Path(
+        ...,
+        description="Identifier to start tracing from (e.g., catchment ID, POI ID)",
+        examples=["01010000"],
+        openapi_examples={"station_example": {"summary": "USGS Gauge", "value": "01010000"}},
+    ),
+):
+    """
+    Get hydrofabric subset as a geopackage file (.gpkg)
+
+    This endpoint creates a subset of the hydrofabric data by tracing upstream
+    from a given identifier and returns all related geospatial layers as a
+    downloadable geopackage file.
+    """
+    catalog = load_catalog("hydrofabric", **catalog_settings)
+    unique_id = str(uuid.uuid4())[:8]
+    temp_dir = pathlib.Path(tempfile.gettempdir())
+    tmp_path = temp_dir / f"hydrofabric_subset_{identifier}_{unique_id}.gpkg"
+    try:
+        # Create the subset
+        subset(catalog=catalog, identifier=f"gages-{identifier}", id_type=IdType.HL_URI, output_file=tmp_path)
+
+        if not tmp_path.exists():
+            raise HTTPException(status_code=500, detail=f"Failed to create geopackage file at {tmp_path}")
+        if tmp_path.stat().st_size == 0:
+            tmp_path.unlink(missing_ok=True)  # Clean up empty file
+            raise HTTPException(status_code=404, detail=f"No data found for identifier '{identifier}'")
+
+        # Verify it's actually a file, not a directory
+        if not tmp_path.is_file():
+            raise HTTPException(status_code=500, detail=f"Expected file but got directory at {tmp_path}")
+
+        print(f"Returning file: {tmp_path} (size: {tmp_path.stat().st_size} bytes)")
+
+        download_filename = f"hydrofabric_subset_{identifier}.gpkg"
+
+        return FileResponse(
+            path=str(tmp_path),
+            filename=download_filename,
+            media_type="application/geopackage+sqlite3",
+            headers={
+                "Content-Description": "Hydrofabric Subset Geopackage",
+                "X-Identifier": identifier,
+            },
+            background=BackgroundTask(lambda: tmp_path.unlink(missing_ok=True)),
+        )
+
+    except HTTPException:
+        raise
+    except Exception:
+        # Clean up temp file if it exists
+        if "tmp_path" in locals() and tmp_path.exists():
+            tmp_path.unlink(missing_ok=True)
+        raise

--- a/src/icefabric_api/app/routers/hydrofabric/test_router.py
+++ b/src/icefabric_api/app/routers/hydrofabric/test_router.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+import geopandas as gpd
+import pytest
+
+
+@pytest.mark.integration
+def test_subset_hl_uri(client, gauge_hf_uri: str, testing_dir: Path, tmp_path: Path):
+    """Test: GET /streamflow_observations/usgs/csv"""
+    response = client.get(
+        f"/v1/hydrofabric/{gauge_hf_uri}/gpkg",
+    )
+
+    assert response.status_code == 200, "Incorrect response"
+
+    if response.status_code == 200:
+        temp_gpkg = tmp_path / "structure_test.gpkg"
+        temp_gpkg.write_bytes(response.content)
+
+        output_gdf = gpd.read_file(temp_gpkg, layer="network")
+        correct_gdf = gpd.read_file(testing_dir / f"gages-{gauge_hf_uri}.gpkg", layer="network")
+        assert output_gdf.equals(correct_gdf)
+
+        output_gdf = gpd.read_file(temp_gpkg, layer="divides")
+        correct_gdf = gpd.read_file(testing_dir / f"gages-{gauge_hf_uri}.gpkg", layer="divides")
+        assert output_gdf.equals(correct_gdf)
+
+        output_gdf = gpd.read_file(temp_gpkg, layer="flowpaths")
+        correct_gdf = gpd.read_file(testing_dir / f"gages-{gauge_hf_uri}.gpkg", layer="flowpaths")
+        assert output_gdf.equals(correct_gdf)
+
+        output_gdf = gpd.read_file(temp_gpkg, layer="nexus")
+        correct_gdf = gpd.read_file(testing_dir / f"gages-{gauge_hf_uri}.gpkg", layer="nexus")
+        assert output_gdf.equals(correct_gdf)


### PR DESCRIPTION
# Added:
- an endpoint to subset the hydrofabric that can be run from the `icefabric_api`
<img width="1466" alt="image" src="https://github.com/user-attachments/assets/2cfb396c-00a8-4cdf-b9c0-16cd40f94ae7" />

# Docs:
more mkdocs have been written for documenting the new routes
<img width="1466" alt="image" src="https://github.com/user-attachments/assets/f1350824-7391-4025-88de-8ccc6e73154a" />


# Tests:
All of the `icefabric_tools/tests/test_subset.py` tests, but for the API, have been provided and can be run through:
```sh
(icefabric) taddbindas in ~/projects/NGWPC/icefabric/src/icefabric_api on NGWPC-6396 λ pytest app  
======================================================================================================== test session starts ========================================================================================================
platform darwin -- Python 3.12.9, pytest-8.3.5, pluggy-1.6.0
rootdir: /Users/taddbindas/projects/NGWPC/icefabric/src/icefabric_api
configfile: pyproject.toml
plugins: anyio-4.9.0
collected 20 items                                                                                                                                                                                                                  

app/routers/hydrofabric/test_router.py ..............                                                                                                                                                                         [ 70%]
app/routers/streamflow_observations/test_router.py .....                                                                                                                                                                      [ 95%]
app/test_main.py .                                                                                                                                                                                                            [100%]

========================================================================================================= warnings summary ==========================================================================================================
../../.venv/lib/python3.12/site-packages/geopandas/_compat.py:7
  /Users/taddbindas/projects/NGWPC/icefabric/.venv/lib/python3.12/site-packages/geopandas/_compat.py:7: DeprecationWarning: The 'shapely.geos' module is deprecated, and will be removed in a future version. All attributes of 'shapely.geos' are available directly from the top-level 'shapely' namespace (since shapely 2.0.0).
    import shapely.geos

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================================== 20 passed, 1 warning in 46.16s ===================================================================================================
```