### PR TITLE
NGWPC-6953 - Build icefabric endpoint to wrap around the USBR API

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -11,8 +11,8 @@ from pyiceberg.catalog import load_catalog
 from app.routers.hydrofabric.router import api_router as hydrofabric_api_router
 from app.routers.nwm_modules.router import sft_router, topoflow_router
 from app.routers.ras_xs.router import api_router as ras_api_router
-from app.routers.streamflow_observations.router import api_router as streamflow_api_router
 from app.routers.rise_wrappers.router import api_router as rise_api_wrap_router
+from app.routers.streamflow_observations.router import api_router as streamflow_api_router
 from icefabric.helpers import load_creds
 
 
@@ -30,6 +30,15 @@ async def lifespan(app: FastAPI):
     yield
 
 
+tags_metadata = [
+    {
+        "name": "RISE",
+        "description": "An interface to the RISE API for querying reservoir outflow data",
+        "externalDocs": {"description": "Link to the RISE API", "url": "https://data.usbr.gov/rise-api"},
+    }
+]
+
+
 app = FastAPI(
     title="Icefabric API",
     description="API for accessing iceberg or icechunk data from EDFS services",
@@ -37,6 +46,7 @@ app = FastAPI(
     docs_url="/docs",
     redoc_url="/redoc",
     lifespan=lifespan,
+    openapi_tags=tags_metadata,
 )
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ from app.routers.hydrofabric.router import api_router as hydrofabric_api_router
 from app.routers.nwm_modules.router import sft_router, topoflow_router
 from app.routers.ras_xs.router import api_router as ras_api_router
 from app.routers.streamflow_observations.router import api_router as streamflow_api_router
+from app.routers.rise_wrappers.router import api_router as rise_api_wrap_router
 from icefabric.helpers import load_creds
 
 
@@ -51,6 +52,7 @@ app.include_router(streamflow_api_router, prefix="/v1")
 app.include_router(sft_router, prefix="/v1")
 app.include_router(topoflow_router, prefix="/v1")
 app.include_router(ras_api_router, prefix="/v1")
+app.include_router(rise_api_wrap_router, prefix="/v1")
 
 
 @app.head(

--- a/app/routers/rise_wrappers/rise_parameters.py
+++ b/app/routers/rise_wrappers/rise_parameters.py
@@ -1,4 +1,3 @@
-from typing import Optional
 from pydantic import BaseModel
 
 # Conversion dict for python-incompatible names found in the RISE API
@@ -18,83 +17,87 @@ PARAM_CONV = {
     "dateTimeStrictlyBefore": "dateTime[strictly_before]",
     "dateTimeAfter": "dateTime[after]",
     "dateTimeStrictlyAfter": "dateTime[strictly_after]",
-    "catalogItemIsModeled": "catalogItem.isModeled"
+    "catalogItemIsModeled": "catalogItem.isModeled",
 }
 
 
 class CatItemParams(BaseModel):
     """Parameters for the catalog-item resource"""
-    page: Optional[int] = 1
-    itemsPerPage: Optional[int] = 25
-    id: Optional[str] = None
-    hasItemStructure: Optional[bool] = None
+
+    page: int | None = 1
+    itemsPerPage: int | None = 25
+    id: str | None = None
+    hasItemStructure: bool | None = None
 
 
 class CatRecParams(BaseModel):
     """Parameters for the catalog-record resource"""
-    page: Optional[int] = 1
-    itemsPerPage: Optional[int] = 25
-    updateDateBefore: Optional[str] = None
-    updateDateStrictlyBefore: Optional[str] = None
-    updateDateAfter: Optional[str] = None
-    updateDateStrictlyAfter: Optional[str] = None
-    id: Optional[str] = None
-    stateId: Optional[str] = None
-    regionId: Optional[str] = None
-    unifiedRegionId: Optional[str] = None
-    locationTypeId: Optional[str] = None
-    themeId: Optional[str] = None
-    itemStructureId: Optional[str] = None
-    generationEffortId: Optional[str] = None
-    search: Optional[str] = None
-    hasItemStructure: Optional[bool] = None
-    hasCatalogItems: Optional[bool] = None
-    orderUpdateDate: Optional[str] = None
-    orderRecordTitle: Optional[str] = None
-    orderId: Optional[str] = None
-    orderFulltext: Optional[str] = None
-    orderLikematch: Optional[str] = None
+
+    page: int | None = 1
+    itemsPerPage: int | None = 25
+    updateDateBefore: str | None = None
+    updateDateStrictlyBefore: str | None = None
+    updateDateAfter: str | None = None
+    updateDateStrictlyAfter: str | None = None
+    id: str | None = None
+    stateId: str | None = None
+    regionId: str | None = None
+    unifiedRegionId: str | None = None
+    locationTypeId: str | None = None
+    themeId: str | None = None
+    itemStructureId: str | None = None
+    generationEffortId: str | None = None
+    search: str | None = None
+    hasItemStructure: bool | None = None
+    hasCatalogItems: bool | None = None
+    orderUpdateDate: str | None = None
+    orderRecordTitle: str | None = None
+    orderId: str | None = None
+    orderFulltext: str | None = None
+    orderLikematch: str | None = None
 
 
 class LocItemParams(BaseModel):
     """Parameters for the location resource"""
-    page: Optional[int] = 1
-    itemsPerPage: Optional[int] = 25
-    id: Optional[str] = None
-    stateId: Optional[str] = None
-    regionId: Optional[str] = None
-    locationTypeId: Optional[str] = None
-    themeId: Optional[str] = None
-    parameterId: Optional[str] = None
-    parameterTimestepId: Optional[str] = None
-    parameterGroupId: Optional[str] = None
-    itemStructureId: Optional[str] = None
-    unifiedRegionId: Optional[str] = None
-    generationEffortId: Optional[str] = None
-    search: Optional[str] = None
-    catalogItemsIsModeled: Optional[bool] = None
-    hasItemStructure: Optional[bool] = None
-    hasCatalogItems: Optional[bool] = None
-    orderUpdateDate: Optional[str] = None
-    orderLocationName: Optional[str] = None
-    orderId: Optional[str] = None
-    orderFulltext: Optional[str] = None
-    orderLikematch: Optional[str] = None
+
+    page: int | None = 1
+    itemsPerPage: int | None = 25
+    id: str | None = None
+    stateId: str | None = None
+    regionId: str | None = None
+    locationTypeId: str | None = None
+    themeId: str | None = None
+    parameterId: str | None = None
+    parameterTimestepId: str | None = None
+    parameterGroupId: str | None = None
+    itemStructureId: str | None = None
+    unifiedRegionId: str | None = None
+    generationEffortId: str | None = None
+    search: str | None = None
+    catalogItemsIsModeled: bool | None = None
+    hasItemStructure: bool | None = None
+    hasCatalogItems: bool | None = None
+    orderUpdateDate: str | None = None
+    orderLocationName: str | None = None
+    orderId: str | None = None
+    orderFulltext: str | None = None
+    orderLikematch: str | None = None
 
 
 class ResParams(BaseModel):
     """Parameters for the result resource"""
-    page: Optional[int] = 1
-    itemsPerPage: Optional[int] = 25
-    id: Optional[str] = None
-    itemId: Optional[str] = None
-    modelRunId: Optional[str] = None
-    locationId: Optional[str] = None
-    parameterId: Optional[str] = None
-    dateTimeBefore: Optional[str] = None
-    dateTimeStrictlyBefore: Optional[str] = None
-    dateTimeAfter: Optional[str] = None
-    dateTimeStrictlyAfter: Optional[str] = None
-    orderDateTime: Optional[str] = None
-    orderId: Optional[str] = None
-    catalogItemIsModeled: Optional[bool] = None
+
+    page: int | None = 1
+    itemsPerPage: int | None = 25
+    id: str | None = None
+    itemId: str | None = None
+    modelRunId: str | None = None
+    locationId: str | None = None
+    parameterId: str | None = None
+    dateTimeBefore: str | None = None
+    dateTimeStrictlyBefore: str | None = None
+    dateTimeAfter: str | None = None
+    dateTimeStrictlyAfter: str | None = None
+    orderDateTime: str | None = None
+    orderId: str | None = None
+    catalogItemIsModeled: bool | None = None

--- a/app/routers/rise_wrappers/rise_parameters.py
+++ b/app/routers/rise_wrappers/rise_parameters.py
@@ -1,0 +1,100 @@
+from typing import Optional
+from pydantic import BaseModel
+
+# Conversion dict for python-incompatible names found in the RISE API
+PARAM_CONV = {
+    "orderUpdateDate": "order[updateDate]",
+    "orderRecordTitle": "order[recordTitle]",
+    "orderLocationName": "order[locationName]",
+    "orderId": "order[id]",
+    "orderFulltext": "order[fulltext]",
+    "orderLikematch": "order[likematch]",
+    "orderDateTime": "order[dateTime]",
+    "updateDateBefore": "updateDate[before]",
+    "updateDateStrictlyBefore": "updateDate[strictly_before]",
+    "updateDateAfter": "updateDate[after]",
+    "updateDateStrictlyAfter": "updateDate[strictly_after]",
+    "dateTimeBefore": "dateTime[before]",
+    "dateTimeStrictlyBefore": "dateTime[strictly_before]",
+    "dateTimeAfter": "dateTime[after]",
+    "dateTimeStrictlyAfter": "dateTime[strictly_after]",
+    "catalogItemIsModeled": "catalogItem.isModeled"
+}
+
+
+class CatItemParams(BaseModel):
+    """Parameters for the catalog-item resource"""
+    page: Optional[int] = 1
+    itemsPerPage: Optional[int] = 25
+    id: Optional[str] = None
+    hasItemStructure: Optional[bool] = None
+
+
+class CatRecParams(BaseModel):
+    """Parameters for the catalog-record resource"""
+    page: Optional[int] = 1
+    itemsPerPage: Optional[int] = 25
+    updateDateBefore: Optional[str] = None
+    updateDateStrictlyBefore: Optional[str] = None
+    updateDateAfter: Optional[str] = None
+    updateDateStrictlyAfter: Optional[str] = None
+    id: Optional[str] = None
+    stateId: Optional[str] = None
+    regionId: Optional[str] = None
+    unifiedRegionId: Optional[str] = None
+    locationTypeId: Optional[str] = None
+    themeId: Optional[str] = None
+    itemStructureId: Optional[str] = None
+    generationEffortId: Optional[str] = None
+    search: Optional[str] = None
+    hasItemStructure: Optional[bool] = None
+    hasCatalogItems: Optional[bool] = None
+    orderUpdateDate: Optional[str] = None
+    orderRecordTitle: Optional[str] = None
+    orderId: Optional[str] = None
+    orderFulltext: Optional[str] = None
+    orderLikematch: Optional[str] = None
+
+
+class LocItemParams(BaseModel):
+    """Parameters for the location resource"""
+    page: Optional[int] = 1
+    itemsPerPage: Optional[int] = 25
+    id: Optional[str] = None
+    stateId: Optional[str] = None
+    regionId: Optional[str] = None
+    locationTypeId: Optional[str] = None
+    themeId: Optional[str] = None
+    parameterId: Optional[str] = None
+    parameterTimestepId: Optional[str] = None
+    parameterGroupId: Optional[str] = None
+    itemStructureId: Optional[str] = None
+    unifiedRegionId: Optional[str] = None
+    generationEffortId: Optional[str] = None
+    search: Optional[str] = None
+    catalogItemsIsModeled: Optional[bool] = None
+    hasItemStructure: Optional[bool] = None
+    hasCatalogItems: Optional[bool] = None
+    orderUpdateDate: Optional[str] = None
+    orderLocationName: Optional[str] = None
+    orderId: Optional[str] = None
+    orderFulltext: Optional[str] = None
+    orderLikematch: Optional[str] = None
+
+
+class ResParams(BaseModel):
+    """Parameters for the result resource"""
+    page: Optional[int] = 1
+    itemsPerPage: Optional[int] = 25
+    id: Optional[str] = None
+    itemId: Optional[str] = None
+    modelRunId: Optional[str] = None
+    locationId: Optional[str] = None
+    parameterId: Optional[str] = None
+    dateTimeBefore: Optional[str] = None
+    dateTimeStrictlyBefore: Optional[str] = None
+    dateTimeAfter: Optional[str] = None
+    dateTimeStrictlyAfter: Optional[str] = None
+    orderDateTime: Optional[str] = None
+    orderId: Optional[str] = None
+    catalogItemIsModeled: Optional[bool] = None

--- a/app/routers/rise_wrappers/router.py
+++ b/app/routers/rise_wrappers/router.py
@@ -1,110 +1,29 @@
-import os
-import requests
-from typing import Optional
-
-from fastapi import APIRouter, HTTPException, Path, Query, Depends
-from fastapi.responses import Response
-from pydantic import BaseModel, Field, ConfigDict
 from urllib.parse import urlencode
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from app.routers.rise_wrappers.rise_parameters import (
+    PARAM_CONV,
+    CatItemParams,
+    CatRecParams,
+    LocItemParams,
+    ResParams,
+)
 
 api_router = APIRouter(prefix="/rise")
 EXT_RISE_BASE_URL = "https://data.usbr.gov/rise/api"
 RISE_HEADERS = {"accept": "application/vnd.api+json"}
-PARAM_CONV = {
-    "orderUpdateDate": "order[updateDate]",
-    "orderRecordTitle": "order[recordTitle]",
-    "orderLocationName": "order[locationName]",
-    "orderId": "order[id]",
-    "orderFulltext": "order[fulltext]",
-    "orderLikematch": "order[likematch]",
-    "orderDateTime": "order[dateTime]",
-    "updateDateBefore": "updateDate[before]",
-    "updateDateStrictlyBefore": "updateDate[strictly_before]",
-    "updateDateAfter": "updateDate[after]",
-    "updateDateStrictlyAfter": "updateDate[strictly_after]",
-    "dateTimeBefore": "dateTime[before]",
-    "dateTimeStrictlyBefore": "dateTime[strictly_before]",
-    "dateTimeAfter": "dateTime[after]",
-    "dateTimeStrictlyAfter": "dateTime[strictly_after]",
-    "catalogItemIsModeled": "catalogItem.isModeled"
-}
-
-
-class LocItemParams(BaseModel):
-    page: Optional[int] = None
-    itemsPerPage: Optional[int] = None
-    id: Optional[str] = None
-    stateId: Optional[str] = None
-    regionId: Optional[str] = None
-    locationTypeId: Optional[str] = None
-    themeId: Optional[str] = None
-    parameterId: Optional[str] = None
-    parameterTimestepId: Optional[str] = None
-    parameterGroupId: Optional[str] = None
-    itemStructureId: Optional[str] = None
-    unifiedRegionId: Optional[str] = None
-    generationEffortId: Optional[str] = None
-    search: Optional[str] = None
-    catalogItemsIsModeled: Optional[bool] = None
-    hasItemStructure: Optional[bool] = None
-    hasCatalogItems: Optional[bool] = None
-    orderUpdateDate: Optional[str] = None
-    orderLocationName: Optional[str] = None
-    orderId: Optional[str] = None
-    orderFulltext: Optional[str] = None
-    orderLikematch: Optional[str] = None
-
-
-class CatItemParams(BaseModel):
-    page: Optional[int] = None
-    itemsPerPage: Optional[int] = None
-    id: Optional[str] = None
-    hasItemStructure: Optional[bool] = None
-
-
-class CatRecParams(BaseModel):
-    page: Optional[int] = None
-    itemsPerPage: Optional[int] = None
-    updateDateBefore: Optional[str] = None
-    updateDateStrictlyBefore: Optional[str] = None
-    updateDateAfter: Optional[str] = None
-    updateDateStrictlyAfter: Optional[str] = None
-    id: Optional[str] = None
-    stateId: Optional[str] = None
-    regionId: Optional[str] = None
-    unifiedRegionId: Optional[str] = None
-    locationTypeId: Optional[str] = None
-    themeId: Optional[str] = None
-    itemStructureId: Optional[str] = None
-    generationEffortId: Optional[str] = None
-    search: Optional[str] = None
-    hasItemStructure: Optional[bool] = None
-    hasCatalogItems: Optional[bool] = None
-    orderUpdateDate: Optional[str] = None
-    orderRecordTitle: Optional[str] = None
-    orderId: Optional[str] = None
-    orderFulltext: Optional[str] = None
-    orderLikematch: Optional[str] = None
-
-
-class ResParams(BaseModel):
-    page: Optional[int] = None
-    itemsPerPage: Optional[int] = None
-    id: Optional[str] = None
-    itemId: Optional[str] = None
-    modelRunId: Optional[str] = None
-    locationId: Optional[str] = None
-    parameterId: Optional[str] = None
-    dateTimeBefore: Optional[str] = None
-    dateTimeStrictlyBefore: Optional[str] = None
-    dateTimeAfter: Optional[str] = None
-    dateTimeStrictlyAfter: Optional[str] = None
-    orderDateTime: Optional[str] = None
-    orderId: Optional[str] = None
-    catalogItemIsModeled: Optional[bool] = None
 
 
 def basemodel_to_query_string(model: BaseModel) -> str:
+    """
+    Encodes a basemodel into the querying string portion of a GET request.
+
+    Also uses the PARAM_CONV definition to convert parameter names that are
+    invalid in python.
+    """
     filtered_params = model.model_dump(exclude_none=True)
     for k in PARAM_CONV.keys():
         if k in filtered_params:
@@ -115,77 +34,107 @@ def basemodel_to_query_string(model: BaseModel) -> str:
     return q_str
 
 
-def make_get_req_to_rise(full_url: str, err_detail: str) -> dict | list:
-    response = requests.get(full_url, headers=RISE_HEADERS)
-    if response.status_code == 200:
-        return response.json()
+async def make_get_req_to_rise(full_url: str):
+    """
+    Makes an asynchronous GET request to the RISE API.
+
+    Returns a response dict with the status code and the message body. If
+    the response is an error from RISE, the original code and message is
+    returned as well.
+    """
+    async with httpx.AsyncClient() as client:
+        try:
+            rise_response = {"status_code": 200, "detail": ""}
+            print(f"Making GET request to RISE (full URL): {full_url}")
+            resp = await client.get(full_url, headers=RISE_HEADERS, timeout=15)
+            resp.raise_for_status()
+            rise_response["detail"] = resp.json()
+        except httpx.HTTPError as err:
+            print(f"RISE API returned an HTTP error: {err}")
+            rise_response["status_code"] = int(err.response.status_code)
+            rise_response["detail"] = err.response.text
+        return rise_response
+
+
+@api_router.get("/catalog-item", tags=["RISE"])
+async def get_catalog_item(query: CatItemParams = Depends()):
+    """Retrieves the collection of CatalogItem resources."""
+    query_url_portion = basemodel_to_query_string(query)
+    rise_response = await make_get_req_to_rise(f"{EXT_RISE_BASE_URL}/catalog-item{query_url_portion}")
+    if rise_response["status_code"] != 200:
+        raise HTTPException(**rise_response)
     else:
-        raise HTTPException(status_code=404, detail=err_detail)
+        return rise_response["detail"]
 
 
-@api_router.get("/location/{id}")
-async def get_loc_by_id(id: str):
-    return make_get_req_to_rise(
-        full_url=f"{EXT_RISE_BASE_URL}/location/{id}",
-        err_detail="Location not found"
-    )
+@api_router.get("/catalog-item/{id}", tags=["RISE"])
+async def get_catalog_item_by_id(id: str):
+    """Retrieves a CatalogItem resource, per a given ID."""
+    rise_response = await make_get_req_to_rise(f"{EXT_RISE_BASE_URL}/catalog-item/{id}")
+    if rise_response["status_code"] != 200:
+        raise HTTPException(**rise_response)
+    else:
+        return rise_response["detail"]
 
 
-@api_router.get("/location")
-async def get_loc(query: LocItemParams = Depends()):
+@api_router.get("/catalog-record", tags=["RISE"])
+async def get_catalog_record(query: CatRecParams = Depends()):
+    """Retrieves the collection of CatalogRecord resources."""
     query_url_portion = basemodel_to_query_string(query)
-    return make_get_req_to_rise(
-        full_url=f"{EXT_RISE_BASE_URL}/location{query_url_portion}",
-        err_detail="Location(s) not found"
-    )
+    rise_response = await make_get_req_to_rise(f"{EXT_RISE_BASE_URL}/catalog-record{query_url_portion}")
+    if rise_response["status_code"] != 200:
+        raise HTTPException(**rise_response)
+    else:
+        return rise_response["detail"]
 
 
-@api_router.get("/catalog-item/{id}")
-async def get_cat_item_by_id(id: str):
-    return make_get_req_to_rise(
-        full_url=f"{EXT_RISE_BASE_URL}/catalog-item/{id}",
-        err_detail="Catalog item not found"
-    )
+@api_router.get("/catalog-record/{id}", tags=["RISE"])
+async def get_catalog_record_by_id(id: str):
+    """Retrieves a CatalogRecord resource, per a given ID."""
+    rise_response = await make_get_req_to_rise(f"{EXT_RISE_BASE_URL}/catalog-record/{id}")
+    if rise_response["status_code"] != 200:
+        raise HTTPException(**rise_response)
+    else:
+        return rise_response["detail"]
 
 
-@api_router.get("/catalog-item")
-async def get_cat_item(query: CatItemParams = Depends()):
+@api_router.get("/location", tags=["RISE"])
+async def get_location(query: LocItemParams = Depends()):
+    """Retrieves the collection of Location resources."""
     query_url_portion = basemodel_to_query_string(query)
-    return make_get_req_to_rise(
-        full_url=f"{EXT_RISE_BASE_URL}/catalog-item{query_url_portion}",
-        err_detail="Catalog item(s) not found"
-    )
+    rise_response = await make_get_req_to_rise(f"{EXT_RISE_BASE_URL}/location{query_url_portion}")
+    if rise_response["status_code"] != 200:
+        raise HTTPException(**rise_response)
+    else:
+        return rise_response["detail"]
 
 
-@api_router.get("/catalog-record/{id}")
-async def get_cat_rec_by_id(id: str):
-    return make_get_req_to_rise(
-        full_url=f"{EXT_RISE_BASE_URL}/catalog-record/{id}",
-        err_detail="Catalog record not found"
-    )
+@api_router.get("/location/{id}", tags=["RISE"])
+async def get_location_by_id(id: str):
+    """Retrieves a Location resource, per a given ID."""
+    rise_response = await make_get_req_to_rise(f"{EXT_RISE_BASE_URL}/location/{id}")
+    if rise_response["status_code"] != 200:
+        raise HTTPException(**rise_response)
+    else:
+        return rise_response["detail"]
 
 
-@api_router.get("/catalog-record")
-async def get_cat_rec(query: CatRecParams = Depends()):
+@api_router.get("/result", tags=["RISE"])
+async def get_result(query: ResParams = Depends()):
+    """Retrieves the collection of Result resources."""
     query_url_portion = basemodel_to_query_string(query)
-    return make_get_req_to_rise(
-        full_url=f"{EXT_RISE_BASE_URL}/catalog-record{query_url_portion}",
-        err_detail="Catalog record(s) not found"
-    )
+    rise_response = await make_get_req_to_rise(f"{EXT_RISE_BASE_URL}/result{query_url_portion}")
+    if rise_response["status_code"] != 200:
+        raise HTTPException(**rise_response)
+    else:
+        return rise_response["detail"]
 
 
-@api_router.get("/result/{id}")
-async def get_res_by_id(id: str):
-    return make_get_req_to_rise(
-        full_url=f"{EXT_RISE_BASE_URL}/result/{id}",
-        err_detail="Result not found"
-    )
-
-
-@api_router.get("/result")
-async def get_res(query: ResParams = Depends()):
-    query_url_portion = basemodel_to_query_string(query)
-    return make_get_req_to_rise(
-        full_url=f"{EXT_RISE_BASE_URL}/result{query_url_portion}",
-        err_detail="Result(s) not found"
-    )
+@api_router.get("/result/{id}", tags=["RISE"])
+async def get_result_by_id(id: str):
+    """Retrieves a Result resource, per a given ID."""
+    rise_response = await make_get_req_to_rise(f"{EXT_RISE_BASE_URL}/result/{id}")
+    if rise_response["status_code"] != 200:
+        raise HTTPException(**rise_response)
+    else:
+        return rise_response["detail"]

--- a/app/routers/rise_wrappers/router.py
+++ b/app/routers/rise_wrappers/router.py
@@ -9,7 +9,6 @@ from app.routers.rise_wrappers.rise_parameters import (
     CatItemParams,
     CatRecParams,
     LocItemParams,
-    ResParams,
 )
 
 api_router = APIRouter(prefix="/rise")
@@ -119,15 +118,16 @@ async def get_location_by_id(id: str):
         return rise_response["detail"]
 
 
-@api_router.get("/result", tags=["RISE"])
-async def get_result(query: ResParams = Depends()):
-    """Retrieves the collection of Result resources."""
-    query_url_portion = basemodel_to_query_string(query)
-    rise_response = await make_get_req_to_rise(f"{EXT_RISE_BASE_URL}/result{query_url_portion}")
-    if rise_response["status_code"] != 200:
-        raise HTTPException(**rise_response)
-    else:
-        return rise_response["detail"]
+# TODO - Restore endpoint once the RISE api/result endpoint is no longer timing out
+# @api_router.get("/result", tags=["RISE"])
+# async def get_result(query: ResParams = Depends()):
+#     """Retrieves the collection of Result resources."""
+#     query_url_portion = basemodel_to_query_string(query)
+#     rise_response = await make_get_req_to_rise(f"{EXT_RISE_BASE_URL}/result{query_url_portion}")
+#     if rise_response["status_code"] != 200:
+#         raise HTTPException(**rise_response)
+#     else:
+#         return rise_response["detail"]
 
 
 @api_router.get("/result/{id}", tags=["RISE"])

--- a/app/routers/rise_wrappers/router.py
+++ b/app/routers/rise_wrappers/router.py
@@ -1,0 +1,191 @@
+import os
+import requests
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Path, Query, Depends
+from fastapi.responses import Response
+from pydantic import BaseModel, Field, ConfigDict
+from urllib.parse import urlencode
+
+api_router = APIRouter(prefix="/rise")
+EXT_RISE_BASE_URL = "https://data.usbr.gov/rise/api"
+RISE_HEADERS = {"accept": "application/vnd.api+json"}
+PARAM_CONV = {
+    "orderUpdateDate": "order[updateDate]",
+    "orderRecordTitle": "order[recordTitle]",
+    "orderLocationName": "order[locationName]",
+    "orderId": "order[id]",
+    "orderFulltext": "order[fulltext]",
+    "orderLikematch": "order[likematch]",
+    "orderDateTime": "order[dateTime]",
+    "updateDateBefore": "updateDate[before]",
+    "updateDateStrictlyBefore": "updateDate[strictly_before]",
+    "updateDateAfter": "updateDate[after]",
+    "updateDateStrictlyAfter": "updateDate[strictly_after]",
+    "dateTimeBefore": "dateTime[before]",
+    "dateTimeStrictlyBefore": "dateTime[strictly_before]",
+    "dateTimeAfter": "dateTime[after]",
+    "dateTimeStrictlyAfter": "dateTime[strictly_after]",
+    "catalogItemIsModeled": "catalogItem.isModeled"
+}
+
+
+class LocItemParams(BaseModel):
+    page: Optional[int] = None
+    itemsPerPage: Optional[int] = None
+    id: Optional[str] = None
+    stateId: Optional[str] = None
+    regionId: Optional[str] = None
+    locationTypeId: Optional[str] = None
+    themeId: Optional[str] = None
+    parameterId: Optional[str] = None
+    parameterTimestepId: Optional[str] = None
+    parameterGroupId: Optional[str] = None
+    itemStructureId: Optional[str] = None
+    unifiedRegionId: Optional[str] = None
+    generationEffortId: Optional[str] = None
+    search: Optional[str] = None
+    catalogItemsIsModeled: Optional[bool] = None
+    hasItemStructure: Optional[bool] = None
+    hasCatalogItems: Optional[bool] = None
+    orderUpdateDate: Optional[str] = None
+    orderLocationName: Optional[str] = None
+    orderId: Optional[str] = None
+    orderFulltext: Optional[str] = None
+    orderLikematch: Optional[str] = None
+
+
+class CatItemParams(BaseModel):
+    page: Optional[int] = None
+    itemsPerPage: Optional[int] = None
+    id: Optional[str] = None
+    hasItemStructure: Optional[bool] = None
+
+
+class CatRecParams(BaseModel):
+    page: Optional[int] = None
+    itemsPerPage: Optional[int] = None
+    updateDateBefore: Optional[str] = None
+    updateDateStrictlyBefore: Optional[str] = None
+    updateDateAfter: Optional[str] = None
+    updateDateStrictlyAfter: Optional[str] = None
+    id: Optional[str] = None
+    stateId: Optional[str] = None
+    regionId: Optional[str] = None
+    unifiedRegionId: Optional[str] = None
+    locationTypeId: Optional[str] = None
+    themeId: Optional[str] = None
+    itemStructureId: Optional[str] = None
+    generationEffortId: Optional[str] = None
+    search: Optional[str] = None
+    hasItemStructure: Optional[bool] = None
+    hasCatalogItems: Optional[bool] = None
+    orderUpdateDate: Optional[str] = None
+    orderRecordTitle: Optional[str] = None
+    orderId: Optional[str] = None
+    orderFulltext: Optional[str] = None
+    orderLikematch: Optional[str] = None
+
+
+class ResParams(BaseModel):
+    page: Optional[int] = None
+    itemsPerPage: Optional[int] = None
+    id: Optional[str] = None
+    itemId: Optional[str] = None
+    modelRunId: Optional[str] = None
+    locationId: Optional[str] = None
+    parameterId: Optional[str] = None
+    dateTimeBefore: Optional[str] = None
+    dateTimeStrictlyBefore: Optional[str] = None
+    dateTimeAfter: Optional[str] = None
+    dateTimeStrictlyAfter: Optional[str] = None
+    orderDateTime: Optional[str] = None
+    orderId: Optional[str] = None
+    catalogItemIsModeled: Optional[bool] = None
+
+
+def basemodel_to_query_string(model: BaseModel) -> str:
+    filtered_params = model.model_dump(exclude_none=True)
+    for k in PARAM_CONV.keys():
+        if k in filtered_params:
+            filtered_params[PARAM_CONV[k]] = filtered_params.pop(k)
+    q_str = urlencode(filtered_params)
+    if q_str != "":
+        q_str = f"?{q_str}"
+    return q_str
+
+
+def make_get_req_to_rise(full_url: str, err_detail: str) -> dict | list:
+    response = requests.get(full_url, headers=RISE_HEADERS)
+    if response.status_code == 200:
+        return response.json()
+    else:
+        raise HTTPException(status_code=404, detail=err_detail)
+
+
+@api_router.get("/location/{id}")
+async def get_loc_by_id(id: str):
+    return make_get_req_to_rise(
+        full_url=f"{EXT_RISE_BASE_URL}/location/{id}",
+        err_detail="Location not found"
+    )
+
+
+@api_router.get("/location")
+async def get_loc(query: LocItemParams = Depends()):
+    query_url_portion = basemodel_to_query_string(query)
+    return make_get_req_to_rise(
+        full_url=f"{EXT_RISE_BASE_URL}/location{query_url_portion}",
+        err_detail="Location(s) not found"
+    )
+
+
+@api_router.get("/catalog-item/{id}")
+async def get_cat_item_by_id(id: str):
+    return make_get_req_to_rise(
+        full_url=f"{EXT_RISE_BASE_URL}/catalog-item/{id}",
+        err_detail="Catalog item not found"
+    )
+
+
+@api_router.get("/catalog-item")
+async def get_cat_item(query: CatItemParams = Depends()):
+    query_url_portion = basemodel_to_query_string(query)
+    return make_get_req_to_rise(
+        full_url=f"{EXT_RISE_BASE_URL}/catalog-item{query_url_portion}",
+        err_detail="Catalog item(s) not found"
+    )
+
+
+@api_router.get("/catalog-record/{id}")
+async def get_cat_rec_by_id(id: str):
+    return make_get_req_to_rise(
+        full_url=f"{EXT_RISE_BASE_URL}/catalog-record/{id}",
+        err_detail="Catalog record not found"
+    )
+
+
+@api_router.get("/catalog-record")
+async def get_cat_rec(query: CatRecParams = Depends()):
+    query_url_portion = basemodel_to_query_string(query)
+    return make_get_req_to_rise(
+        full_url=f"{EXT_RISE_BASE_URL}/catalog-record{query_url_portion}",
+        err_detail="Catalog record(s) not found"
+    )
+
+
+@api_router.get("/result/{id}")
+async def get_res_by_id(id: str):
+    return make_get_req_to_rise(
+        full_url=f"{EXT_RISE_BASE_URL}/result/{id}",
+        err_detail="Result not found"
+    )
+
+
+@api_router.get("/result")
+async def get_res(query: ResParams = Depends()):
+    query_url_portion = basemodel_to_query_string(query)
+    return make_get_req_to_rise(
+        full_url=f"{EXT_RISE_BASE_URL}/result{query_url_portion}",
+        err_detail="Result(s) not found"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ examples = [
 ]
 tests = [
     "pytest==8.4.1",
+    "pytest-asyncio==1.1.0",
     "pytest-cov==6.1.1",
 ]
 

--- a/tests/app/test_rise_router.py
+++ b/tests/app/test_rise_router.py
@@ -1,0 +1,61 @@
+import asyncio
+import pytest
+import json
+from app.routers.rise_wrappers.router import EXT_RISE_BASE_URL, make_get_req_to_rise
+
+
+resources = [
+    "catalog-item", "catalog-record", "location", "result"
+]
+
+good_ids = [
+    "10835", "4462", "3672", "3672"
+]
+
+bad_ids = [
+    "0", "0", "0", "0"
+]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.parametrize("resource_type,id", list(zip(resources, good_ids)))
+async def test_get_item_by_id_good(client, resource_type, id):
+    """Test all per-ID endpoints for IDs that exist"""
+    response = client.get(f"/v1/rise/{resource_type}/{id}")
+    assert response.status_code == 200
+    rise_direct_response = await make_get_req_to_rise(f"{EXT_RISE_BASE_URL}/{resource_type}/{id}")
+    assert json.loads(response.text) == rise_direct_response["detail"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.parametrize("resource_type,id", list(zip(resources, bad_ids)))
+async def test_get_item_by_id_bad(client, resource_type, id):
+    """Test all per-ID endpoints for IDs that do not exist"""
+    response = client.get(f"/v1/rise/{resource_type}/{id}")
+    assert response.status_code == 404
+    rise_direct_response = await make_get_req_to_rise(f"{EXT_RISE_BASE_URL}/{resource_type}/{id}")
+    assert json.loads(response.text)["detail"] == rise_direct_response["detail"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.parametrize("resource_type", resources)
+async def test_get_collection(client, resource_type):
+    """Test every resource collection endpoint - all default parameters"""
+    response = client.get(f"/v1/rise/{resource_type}")
+    assert response.status_code == 200
+    rise_direct_response = await make_get_req_to_rise(f"{EXT_RISE_BASE_URL}/{resource_type}")
+    assert json.loads(response.text)["data"] == rise_direct_response["detail"]["data"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.parametrize("resource_type", resources)
+async def test_get_collection_set_of_ids(client, resource_type):
+    """Test every resource collection endpoint with a set of three IDs"""
+    response = client.get(f"/v1/rise/{resource_type}?id=3672,4462,10835")
+    assert response.status_code == 200
+    rise_direct_response = await make_get_req_to_rise(f"{EXT_RISE_BASE_URL}/{resource_type}?id=3672,4462,10835")
+    assert json.loads(response.text)["data"] == rise_direct_response["detail"]["data"]

--- a/tests/app/test_rise_router.py
+++ b/tests/app/test_rise_router.py
@@ -1,25 +1,19 @@
-import asyncio
-import pytest
 import json
+
+import pytest
+
 from app.routers.rise_wrappers.router import EXT_RISE_BASE_URL, make_get_req_to_rise
 
+resources = ["catalog-item", "catalog-record", "location", "result"]
 
-resources = [
-    "catalog-item", "catalog-record", "location", "result"
-]
+good_ids = ["10835", "4462", "3672", "3672"]
 
-good_ids = [
-    "10835", "4462", "3672", "3672"
-]
-
-bad_ids = [
-    "0", "0", "0", "0"
-]
+bad_ids = ["0", "0", "0", "0"]
 
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-@pytest.mark.parametrize("resource_type,id", list(zip(resources, good_ids)))
+@pytest.mark.parametrize("resource_type,id", list(zip(resources, good_ids, strict=False)))
 async def test_get_item_by_id_good(client, resource_type, id):
     """Test all per-ID endpoints for IDs that exist"""
     response = client.get(f"/v1/rise/{resource_type}/{id}")
@@ -30,7 +24,7 @@ async def test_get_item_by_id_good(client, resource_type, id):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-@pytest.mark.parametrize("resource_type,id", list(zip(resources, bad_ids)))
+@pytest.mark.parametrize("resource_type,id", list(zip(resources, bad_ids, strict=False)))
 async def test_get_item_by_id_bad(client, resource_type, id):
     """Test all per-ID endpoints for IDs that do not exist"""
     response = client.get(f"/v1/rise/{resource_type}/{id}")
@@ -44,6 +38,9 @@ async def test_get_item_by_id_bad(client, resource_type, id):
 @pytest.mark.parametrize("resource_type", resources)
 async def test_get_collection(client, resource_type):
     """Test every resource collection endpoint - all default parameters"""
+    # TODO - remove skip once the RISE api/result endpoint is no longer timing out
+    if resource_type == "result":
+        pytest.skip(f"Skipping {resource_type} endpoint test until RISE API endpoint stops timing out.")
     response = client.get(f"/v1/rise/{resource_type}")
     assert response.status_code == 200
     rise_direct_response = await make_get_req_to_rise(f"{EXT_RISE_BASE_URL}/{resource_type}")
@@ -55,7 +52,12 @@ async def test_get_collection(client, resource_type):
 @pytest.mark.parametrize("resource_type", resources)
 async def test_get_collection_set_of_ids(client, resource_type):
     """Test every resource collection endpoint with a set of three IDs"""
+    # TODO - remove skip once the RISE api/result endpoint is no longer timing out
+    if resource_type == "result":
+        pytest.skip(f"Skipping {resource_type} endpoint test until RISE API endpoint stops timing out.")
     response = client.get(f"/v1/rise/{resource_type}?id=3672,4462,10835")
     assert response.status_code == 200
-    rise_direct_response = await make_get_req_to_rise(f"{EXT_RISE_BASE_URL}/{resource_type}?id=3672,4462,10835")
+    rise_direct_response = await make_get_req_to_rise(
+        f"{EXT_RISE_BASE_URL}/{resource_type}?id=3672,4462,10835"
+    )
     assert json.loads(response.text)["data"] == rise_direct_response["detail"]["data"]


### PR DESCRIPTION
## Issue Addressed

Introduces new endpoints into Icefabric that wrap around some RISE API endpoints

Fixes #69

## Description

- New endpoints added that mirror the names and parameters of some RISE API endpoints.
- The endpoints take the GET query and pass it along to RISE. The result is then passed back to the user of Icefabric.
- Uses BaseModel to programmatically define the parameters sent to Icefabric. Utilzing features of Pydantic made this possible with GET endpoints.
- Some parameters with Python-incompatible naming conventions had to be renamed. The backend still generates the requests to RISE with the original parameter names.


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code cleanup/refactor
- [ ] Documentation update

Other (please specify):

## Checklist

- [x] Branch is up to date with master
- [x] Updated tests or added new tests
- [x] Tests & pre-commit hooks pass
- [ ] Updated documentation (if applicable)
- [x] Code follows established style and conventions
