### PR TITLE
NGWPC-7255 - Make NWM Module Endpoints

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -37,8 +37,8 @@ tags_metadata = [
         "externalDocs": {"description": "Link to the RISE API", "url": "https://data.usbr.gov/rise-api"},
     },
     {
-        "name": "HF Modules",
-        "description": "Functions that interact with the Hydrofabric modules. Mainly supports IPE generation.",
+        "name": "NWM Modules",
+        "description": "Functions that interact with NWM modules. Mainly supports IPE generation.",
     },
 ]
 

--- a/app/main.py
+++ b/app/main.py
@@ -9,7 +9,18 @@ from pydantic import BaseModel
 from pyiceberg.catalog import load_catalog
 
 from app.routers.hydrofabric.router import api_router as hydrofabric_api_router
-from app.routers.nwm_modules.router import sft_router, topoflow_router
+from app.routers.nwm_modules.router import (
+    lasam_router,
+    lstm_router,
+    noahowp_router,
+    sacsma_router,
+    sft_router,
+    smp_router,
+    snow17_router,
+    topmodel_router,
+    topoflow_router,
+    troute_router,
+)
 from app.routers.ras_xs.router import api_router as ras_api_router
 from app.routers.rise_wrappers.router import api_router as rise_api_wrap_router
 from app.routers.streamflow_observations.router import api_router as streamflow_api_router
@@ -19,6 +30,15 @@ tags_metadata = [
     {
         "name": "Hydrofabric Services",
         "description": "Data Querying functions for the Hydrofabric",
+    },
+    {
+        "name": "RISE",
+        "description": "An interface to the RISE API for querying reservoir outflow data",
+        "externalDocs": {"description": "Link to the RISE API", "url": "https://data.usbr.gov/rise-api"},
+    },
+    {
+        "name": "HF Modules",
+        "description": "Functions that interact with the Hydrofabric modules. Mainly supports IPE generation.",
     },
 ]
 
@@ -35,15 +55,6 @@ async def lifespan(app: FastAPI):
     catalog_path = os.getenv("CATALOG_PATH")
     app.state.catalog = load_catalog(catalog_path)
     yield
-
-
-tags_metadata = [
-    {
-        "name": "RISE",
-        "description": "An interface to the RISE API for querying reservoir outflow data",
-        "externalDocs": {"description": "Link to the RISE API", "url": "https://data.usbr.gov/rise-api"},
-    }
-]
 
 
 app = FastAPI(
@@ -67,6 +78,14 @@ class HealthCheck(BaseModel):
 app.include_router(hydrofabric_api_router, prefix="/v1")
 app.include_router(streamflow_api_router, prefix="/v1")
 app.include_router(sft_router, prefix="/v1")
+app.include_router(snow17_router, prefix="/v1")
+app.include_router(smp_router, prefix="/v1")
+app.include_router(lstm_router, prefix="/v1")
+app.include_router(lasam_router, prefix="/v1")
+app.include_router(noahowp_router, prefix="/v1")
+app.include_router(sacsma_router, prefix="/v1")
+app.include_router(troute_router, prefix="/v1")
+app.include_router(topmodel_router, prefix="/v1")
 app.include_router(topoflow_router, prefix="/v1")
 app.include_router(ras_api_router, prefix="/v1")
 app.include_router(rise_api_wrap_router, prefix="/v1")

--- a/app/routers/nwm_modules/router.py
+++ b/app/routers/nwm_modules/router.py
@@ -1,25 +1,84 @@
-from fastapi import APIRouter, Depends, Query
+import json
+from enum import Enum
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pyiceberg.catalog import Catalog
 
 from app import get_catalog
-from icefabric.modules import get_sft_parameters
-from icefabric.schemas import SFT, Albedo, HydrofabricDomains
+from icefabric.modules import config_mapper
+from icefabric.schemas import HydrofabricDomains
+from icefabric.schemas.modules import (
+    LASAM,
+    LSTM,
+    SFT,
+    SMP,
+    Albedo,
+    NoahOwpModular,
+    SacSma,
+    Snow17,
+    Topmodel,
+    TRoute,
+)
 
 sft_router = APIRouter(prefix="/modules/sft")
+snow17_router = APIRouter(prefix="/modules/snow17")
+smp_router = APIRouter(prefix="/modules/smp")
+lstm_router = APIRouter(prefix="/modules/lstm")
+lasam_router = APIRouter(prefix="/modules/lasam")
+noahowp_router = APIRouter(prefix="/modules/noahowp")
+sacsma_router = APIRouter(prefix="/modules/sacsma")
+troute_router = APIRouter(prefix="/modules/troute")
+topmodel_router = APIRouter(prefix="/modules/topmodel")
 topoflow_router = APIRouter(prefix="/modules/topoflow")
 
 
-@sft_router.get("/")
+class SmpModules(str, Enum):
+    """Enum class for defining acceptable inputs for the SMP module variable"""
+
+    cfe_s = "CFE-S"
+    cfe_x = "CFE-X"
+    lasam = "LASAM"
+    topmodel = "TopModel"
+
+
+def load_upstream_connections(domain_val):
+    """Helper function to generate the upstream_dict"""
+    try:
+        # Load upstream connections (same as CLI)
+        upstream_connections_path = (
+            Path(__file__).parents[3] / f"data/hydrofabric/{domain_val}_upstream_connections.json"
+        )
+
+        if not upstream_connections_path.exists():
+            raise HTTPException(
+                status_code=400,
+                detail=f"Upstream connections missing for {domain_val}. Please run `icefabric build-upstream-connections` to generate this file",
+            )
+
+        with open(upstream_connections_path) as f:
+            data = json.load(f)
+            print(
+                f"Loading upstream connections generated on: {data['_metadata']['generated_at']} "
+                f"from snapshot id: {data['_metadata']['iceberg']['snapshot_id']}"
+            )
+            upstream_dict = data["upstream_connections"]
+    except HTTPException:
+        raise
+    return upstream_dict
+
+
+@sft_router.get("/", tags=["HF Modules"])
 async def get_sft_ipes(
     identifier: str = Query(
         ...,
-        description="Gauge ID to trace upstream catchments from",
+        description="Gage ID from which to trace upstream catchments.",
         examples=["01010000"],
         openapi_examples={"sft_example": {"summary": "SFT Example", "value": "01010000"}},
     ),
     domain: HydrofabricDomains = Query(
         HydrofabricDomains.CONUS,
-        description="The iceberg namespace used to query the hydrofabric",
+        description="The iceberg namespace used to query the hydrofabric.",
         openapi_examples={"sft_example": {"summary": "SFT Example", "value": "conus_hf"}},
     ),
     use_schaake: bool = Query(
@@ -32,26 +91,399 @@ async def get_sft_ipes(
     """
     An endpoint to return configurations for SFT.
 
-    This endpoint traces upstream from a given gauge ID to get all catchments
+    This endpoint traces upstream from a given gage ID to get all catchments
     and returns SFT (Soil Freeze-Thaw) parameter configurations for each catchment.
 
     **Parameters:**
-    - **identifier**: The Gauge ID to trace upstream from to get all catchments
+    - **identifier**: The Gage ID to trace upstream from to get all catchments
     - **domain**: The geographic domain to search for catchments from
     - **use_schaake**: Determines if we're using Schaake or Xinanjiang to calculate ice fraction
 
     **Returns:**
     A list of SFT pydantic objects for each catchment
     """
-    return get_sft_parameters(
+    upstream_dict = load_upstream_connections(domain.value)
+    return config_mapper["sft"](
         catalog=catalog,
-        domain=domain,
-        identifier=identifier,
+        namespace=domain.value,
+        identifier=f"gages-{identifier}",
+        upstream_dict=upstream_dict,
         use_schaake=use_schaake,
     )
 
 
-@topoflow_router.get("/albedo")
+@snow17_router.get("/", tags=["HF Modules"])
+async def get_snow17_ipes(
+    identifier: str = Query(
+        ...,
+        description="Gage ID from which to trace upstream catchments.",
+        examples=["01010000"],
+        openapi_examples={"snow17_example": {"summary": "SNOW-17 Example", "value": "01010000"}},
+    ),
+    domain: HydrofabricDomains = Query(
+        HydrofabricDomains.CONUS,
+        description="The iceberg namespace used to query the hydrofabric.",
+        openapi_examples={"snow17_example": {"summary": "SNOW-17 Example", "value": "conus_hf"}},
+    ),
+    envca: bool = Query(
+        False,
+        description="If source is ENVCA, then set to True. Defaults to False.",
+        openapi_examples={"sft_example": {"summary": "SNOW-17 Example", "value": False}},
+    ),
+    catalog: Catalog = Depends(get_catalog),
+) -> list[Snow17]:
+    """
+    An endpoint to return configurations for SNOW-17.
+
+    This endpoint traces upstream from a given gage ID to get all catchments
+    and returns SNOW-17 (Snow Accumulation and Ablation Model) parameter configurations for each catchment.
+
+    **Parameters:**
+    - **identifier**: The Gage ID from which upstream catchments are traced.
+    - **domain**: The geographic domain used to filter catchments.
+    - **envca**: Designates that the source is ENVCA.
+
+    **Returns:**
+    A list of SNOW-17 pydantic objects for each catchment.
+    """
+    upstream_dict = load_upstream_connections(domain.value)
+    return config_mapper["snow17"](
+        catalog=catalog,
+        namespace=domain.value,
+        identifier=f"gages-{identifier}",
+        upstream_dict=upstream_dict,
+        envca=envca,
+    )
+
+
+@smp_router.get("/", tags=["HF Modules"])
+async def get_smp_ipes(
+    identifier: str = Query(
+        ...,
+        description="Gage ID from which to trace upstream catchments.",
+        examples=["01010000"],
+        openapi_examples={"smp_example": {"summary": "SMP Example", "value": "01010000"}},
+    ),
+    domain: HydrofabricDomains = Query(
+        HydrofabricDomains.CONUS,
+        description="The iceberg namespace used to query the hydrofabric.",
+        openapi_examples={"smp_example": {"summary": "SMP Example", "value": "conus_hf"}},
+    ),
+    module: SmpModules = Query(
+        None,
+        description="A setting to determine if a module should be specified to obtain additional SMP parameters.",
+        openapi_examples={"smp_example": {"summary": "SMP Example", "value": None}},
+    ),
+    catalog: Catalog = Depends(get_catalog),
+) -> list[SMP]:
+    """
+    An endpoint to return configurations for SMP.
+
+    This endpoint traces upstream from a given gage ID to get all catchments
+    and returns SMP (Soil Moisture Profile) parameter configurations for each catchment.
+
+    **Parameters:**
+    - **identifier**: The Gage ID from which upstream catchments are traced.
+    - **domain**: The geographic domain used to filter catchments.
+    - **module**: Denotes if another module should be used to obtain additional SMP parameters. Confined to certain modules.
+
+    **Returns:**
+    A list of SMP pydantic objects for each catchment.
+    """
+    upstream_dict = load_upstream_connections(domain.value)
+    return config_mapper["smp"](
+        catalog=catalog,
+        namespace=domain.value,
+        identifier=f"gages-{identifier}",
+        upstream_dict=upstream_dict,
+        module=module,
+    )
+
+
+@lstm_router.get("/", tags=["HF Modules"])
+async def get_lstm_ipes(
+    identifier: str = Query(
+        ...,
+        description="Gage ID from which to trace upstream catchments.",
+        examples=["01010000"],
+        openapi_examples={"lstm_example": {"summary": "LSTM Example", "value": "01010000"}},
+    ),
+    domain: HydrofabricDomains = Query(
+        HydrofabricDomains.CONUS,
+        description="The iceberg namespace used to query the hydrofabric.",
+        openapi_examples={"lstm_example": {"summary": "LSTM Example", "value": "conus_hf"}},
+    ),
+    catalog: Catalog = Depends(get_catalog),
+) -> list[LSTM]:
+    """
+    An endpoint to return configurations for LSTM.
+
+    This endpoint traces upstream from a given gage ID to get all catchments
+    and returns LSTM (Long Short-Term Memory) parameter configurations for each catchment.
+
+    **Parameters:**
+    - **identifier**: The Gage ID from which upstream catchments are traced.
+    - **domain**: The geographic domain used to filter catchments.
+
+    **Returns:**
+    A list of LSTM pydantic objects for each catchment.
+    """
+    upstream_dict = load_upstream_connections(domain.value)
+    return config_mapper["lstm"](
+        catalog=catalog,
+        namespace=domain.value,
+        identifier=f"gages-{identifier}",
+        upstream_dict=upstream_dict,
+    )
+
+
+@lasam_router.get("/", tags=["HF Modules"])
+async def get_lasam_ipes(
+    identifier: str = Query(
+        ...,
+        description="Gage ID from which to trace upstream catchments.",
+        examples=["01010000"],
+        openapi_examples={"lasam_example": {"summary": "LASAM Example", "value": "01010000"}},
+    ),
+    domain: HydrofabricDomains = Query(
+        HydrofabricDomains.CONUS,
+        description="The iceberg namespace used to query the hydrofabric.",
+        openapi_examples={"lasam_example": {"summary": "LASAM Example", "value": "conus_hf"}},
+    ),
+    sft_included: bool = Query(
+        False,
+        description='True if SFT is in the "dep_modules_included" definition as declared in HF API repo.',
+        openapi_examples={"lasam_example": {"summary": "LASAM Example", "value": False}},
+    ),
+    soil_params_file: str = Query(
+        "vG_default_params_HYDRUS.dat",
+        description="Name of the Van Genuchton soil parameters file. Note: This is the filename that gets returned by HF API's utility script get_hydrus_data().",
+        openapi_examples={
+            "lasam_example": {"summary": "LASAM Example", "value": "vG_default_params_HYDRUS.dat"}
+        },
+    ),
+    catalog: Catalog = Depends(get_catalog),
+) -> list[LASAM]:
+    r"""
+    An endpoint to return configurations for LASAM.
+
+    This endpoint traces upstream from a given gage ID to get all catchments
+    and returns LASAM (Lumped Arid/Semi-arid Model) parameter configurations for each catchment.
+
+    **Parameters:**
+    - **identifier**: The Gage ID from which upstream catchments are traced.
+    - **domain**: The geographic domain used to filter catchments.
+    - **sft_included**: Denotes that SFT is in the \"dep_modules_included\" definition as declared in the HF API repo.
+    - **soil_params_file**: Name of the Van Genuchton soil parameters file.
+
+    **Returns:**
+    A list of LASAM pydantic objects for each catchment.
+    """
+    upstream_dict = load_upstream_connections(domain.value)
+    return config_mapper["lasam"](
+        catalog=catalog,
+        namespace=domain.value,
+        identifier=f"gages-{identifier}",
+        upstream_dict=upstream_dict,
+        sft_included=sft_included,
+        soil_params_file=soil_params_file,
+    )
+
+
+@noahowp_router.get("/", tags=["HF Modules"])
+async def get_noahowp_ipes(
+    identifier: str = Query(
+        ...,
+        description="Gage ID from which to trace upstream catchments.",
+        examples=["01010000"],
+        openapi_examples={"noahowp_example": {"summary": "Noah-OWP-Modular Example", "value": "01010000"}},
+    ),
+    domain: HydrofabricDomains = Query(
+        HydrofabricDomains.CONUS,
+        description="The iceberg namespace used to query the hydrofabric.",
+        openapi_examples={"noahowp_example": {"summary": "Noah-OWP-Modular Example", "value": "conus_hf"}},
+    ),
+    catalog: Catalog = Depends(get_catalog),
+) -> list[NoahOwpModular]:
+    """
+    An endpoint to return configurations for Noah-OWP-Modular.
+
+    This endpoint traces upstream from a given gage ID to get all catchments
+    and returns Noah-OWP-Modular parameter configurations for each catchment.
+
+    **Parameters:**
+    - **identifier**: The Gage ID from which upstream catchments are traced.
+    - **domain**: The geographic domain used to filter catchments.
+
+    **Returns:**
+    A list of Noah-OWP-Modular pydantic objects for each catchment.
+    """
+    upstream_dict = load_upstream_connections(domain.value)
+    return config_mapper["noah_owp"](
+        catalog=catalog,
+        namespace=domain.value,
+        identifier=f"gages-{identifier}",
+        upstream_dict=upstream_dict,
+    )
+
+
+@sacsma_router.get("/", tags=["HF Modules"])
+async def get_sacsma_ipes(
+    identifier: str = Query(
+        ...,
+        description="Gage ID from which to trace upstream catchments.",
+        examples=["01010000"],
+        openapi_examples={"sacsma_example": {"summary": "SAC-SMA Example", "value": "01010000"}},
+    ),
+    domain: HydrofabricDomains = Query(
+        HydrofabricDomains.CONUS,
+        description="The iceberg namespace used to query the hydrofabric.",
+        openapi_examples={"sacsma_example": {"summary": "SAC-SMA Example", "value": "conus_hf"}},
+    ),
+    envca: bool = Query(
+        False,
+        description="If source is ENVCA, then set to True. Defaults to False.",
+        openapi_examples={"sacsma_example": {"summary": "SAC-SMA Example", "value": False}},
+    ),
+    catalog: Catalog = Depends(get_catalog),
+) -> list[SacSma]:
+    """
+    An endpoint to return configurations for SAC-SMA.
+
+    This endpoint traces upstream from a given gage ID to get all catchments
+    and returns SAC-SMA (Sacramento Soil Moisture Accounting) parameter configurations for each catchment.
+
+    **Parameters:**
+    - **identifier**: The Gage ID from which upstream catchments are traced.
+    - **domain**: The geographic domain used to filter catchments.
+    - **envca**: Designates that the source is ENVCA.
+
+    **Returns:**
+    A list of SAC-SMA pydantic objects for each catchment.
+    """
+    upstream_dict = load_upstream_connections(domain.value)
+    return config_mapper["sacsma"](
+        catalog=catalog,
+        namespace=domain.value,
+        identifier=f"gages-{identifier}",
+        upstream_dict=upstream_dict,
+        envca=envca,
+    )
+
+
+@troute_router.get("/", tags=["HF Modules"])
+async def get_troute_ipes(
+    identifier: str = Query(
+        ...,
+        description="Gage ID from which to trace upstream catchments.",
+        examples=["01010000"],
+        openapi_examples={"troute_example": {"summary": "T-Route Example", "value": "01010000"}},
+    ),
+    domain: HydrofabricDomains = Query(
+        HydrofabricDomains.CONUS,
+        description="The iceberg namespace used to query the hydrofabric.",
+        openapi_examples={"troute_example": {"summary": "T-Route Example", "value": "conus_hf"}},
+    ),
+    catalog: Catalog = Depends(get_catalog),
+) -> list[TRoute]:
+    """
+    An endpoint to return configurations for T-Route.
+
+    This endpoint traces upstream from a given gage ID to get all catchments
+    and returns T-Route (Tree-Based Channel Routing) parameter configurations for each catchment.
+
+    **Parameters:**
+    - **identifier**: The Gage ID from which upstream catchments are traced.
+    - **domain**: The geographic domain used to filter catchments.
+
+    **Returns:**
+    A list of T-Route pydantic objects for each catchment.
+    """
+    upstream_dict = load_upstream_connections(domain.value)
+    return config_mapper["troute"](
+        catalog=catalog,
+        namespace=domain.value,
+        identifier=f"gages-{identifier}",
+        upstream_dict=upstream_dict,
+    )
+
+
+@topmodel_router.get("/", tags=["HF Modules"])
+async def get_topmodel_ipes(
+    identifier: str = Query(
+        ...,
+        description="Gage ID from which to trace upstream catchments.",
+        examples=["01010000"],
+        openapi_examples={"topmodel_example": {"summary": "TOPMODEL Example", "value": "01010000"}},
+    ),
+    domain: HydrofabricDomains = Query(
+        HydrofabricDomains.CONUS,
+        description="The iceberg namespace used to query the hydrofabric.",
+        openapi_examples={"topmodel_example": {"summary": "TOPMODEL Example", "value": "conus_hf"}},
+    ),
+    catalog: Catalog = Depends(get_catalog),
+) -> list[Topmodel]:
+    """
+    An endpoint to return configurations for TOPMODEL.
+
+    This endpoint traces upstream from a given gage ID to get all catchments
+    and returns TOPMODEL parameter configurations for each catchment.
+
+    **Parameters:**
+    - **identifier**: The Gage ID from which upstream catchments are traced.
+    - **domain**: The geographic domain used to filter catchments.
+
+    **Returns:**
+    A list of TOPMODEL pydantic objects for each catchment.
+    """
+    upstream_dict = load_upstream_connections(domain.value)
+    return config_mapper["topmodel"](
+        catalog=catalog,
+        namespace=domain.value,
+        identifier=f"gages-{identifier}",
+        upstream_dict=upstream_dict,
+    )
+
+
+# TODO - Restore endpoint once the generation of IPEs for TopoFlow is possible/implemented
+# @topoflow_router.get("/", tags=["HF Modules"])
+# async def get_topoflow_ipes(
+#     identifier: str = Query(
+#         ...,
+#         description="Gage ID from which to trace upstream catchments.",
+#         examples=["01010000"],
+#         openapi_examples={"topoflow_example": {"summary": "TopoFlow Example", "value": "01010000"}},
+#     ),
+#     domain: HydrofabricDomains = Query(
+#         HydrofabricDomains.CONUS,
+#         description="The iceberg namespace used to query the hydrofabric.",
+#         openapi_examples={"topoflow_example": {"summary": "TopoFlow Example", "value": "conus_hf"}},
+#     ),
+#     catalog: Catalog = Depends(get_catalog),
+# ) -> list[Topoflow]:
+#     """
+#     An endpoint to return configurations for TopoFlow.
+#
+#     This endpoint traces upstream from a given gage ID to get all catchments
+#     and returns TopoFlow parameter configurations for each catchment.
+#
+#     **Parameters:**
+#     - **identifier**: The Gage ID from which upstream catchments are traced.
+#     - **domain**: The geographic domain used to filter catchments.
+#
+#     **Returns:**
+#     A list of TopoFlow pydantic objects for each catchment.
+#     """
+#     upstream_dict = load_upstream_connections(domain.value)
+#     return config_mapper["topoflow"](
+#         catalog=catalog,
+#         namespace=domain.value,
+#         identifier=f"gages-{identifier}",
+#         upstream_dict=upstream_dict,
+#     )
+
+
+@topoflow_router.get("/albedo", tags=["HF Modules"])
 async def get_albedo(
     landcover_state: Albedo = Query(
         ...,

--- a/src/icefabric/modules/create_ipes.py
+++ b/src/icefabric/modules/create_ipes.py
@@ -261,19 +261,20 @@ def get_smp_parameters(
     water_depth_layers = "NA"
     water_table_depth = "NA"
 
-    if module == "CFE-S" or module == "CFE-X":
-        soil_storage_model = SoilScheme.CFE_SOIL_STORAGE.value
-        soil_storage_depth = SoilScheme.CFE_STORAGE_DEPTH.value
-    elif module == "TopModel":
-        soil_storage_model = SoilScheme.TOPMODEL_SOIL_STORAGE.value
-        water_table_based_method = SoilScheme.TOPMODEL_WATER_TABLE_METHOD.value
-    elif module == "LASAM":
-        soil_storage_model = SoilScheme.LASAM_SOIL_STORAGE.value
-        soil_moisture_profile_option = SoilScheme.LASAM_SOIL_MOISTURE.value
-        soil_depth_layers = SoilScheme.LASAM_SOIL_DEPTH_LAYERS.value
-        water_table_depth = SoilScheme.LASAM_WATER_TABLE_DEPTH.value
-    else:
-        raise ValueError(f"Passing unsupported module into endpoint: {module}")
+    if module:
+        if module == "CFE-S" or module == "CFE-X":
+            soil_storage_model = SoilScheme.CFE_SOIL_STORAGE.value
+            soil_storage_depth = SoilScheme.CFE_STORAGE_DEPTH.value
+        elif module == "TopModel":
+            soil_storage_model = SoilScheme.TOPMODEL_SOIL_STORAGE.value
+            water_table_based_method = SoilScheme.TOPMODEL_WATER_TABLE_METHOD.value
+        elif module == "LASAM":
+            soil_storage_model = SoilScheme.LASAM_SOIL_STORAGE.value
+            soil_moisture_profile_option = SoilScheme.LASAM_SOIL_MOISTURE.value
+            soil_depth_layers = SoilScheme.LASAM_SOIL_DEPTH_LAYERS.value
+            water_table_depth = SoilScheme.LASAM_WATER_TABLE_DEPTH.value
+        else:
+            raise ValueError(f"Passing unsupported module into endpoint: {module}")
 
     pydantic_models = []
     for row_dict in result_df.iter_rows(named=True):

--- a/src/icefabric/schemas/modules.py
+++ b/src/icefabric/schemas/modules.py
@@ -870,7 +870,6 @@ class TRoute(BaseModel):
     log_param: dict = Field(default=log_param, description="Log Parameters")
     nwtopo_param: dict = Field(default=nwtopo_param, description="Network Topology Parameters")
     comp_param: dict = Field(default=comp_param, description="Compute Parameters")
-    output_param: dict = Field(default=output_param, description="Output Parameters")
     res_da: dict = Field(default=res_da, description="Res DA parameters for computation")
     stream_da: dict = Field(default=stream_da, description="Stream parameters for computation")
     output_param: dict = Field(default=output_param, description="Output Parameters")


### PR DESCRIPTION
## Issue Addressed

Add NWM module IPE generation endpoints to Icefabric.

Fixes #69 

## Description

- Added 7 new endpoints representing the NWM modules. They all follow the same structure and wrap around `create_ipes.py` equivalent, module-specific functions.
- TopoFlow was omitted until the IPE generation was added or solved.
- Some refactoring was necessary to accommodate recent changes, as well as the `upstream_dict` addition.
- Redundant T-Route parameter was removed from Pydantic model - it was breaking the JSON serialization.
- Swagger docs updated.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code cleanup/refactor
- [x] Documentation update

Other (please specify):

## Checklist

- [x] Branch is up to date with master
- [ ] Updated tests or added new tests
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation (if applicable)
- [x] Code follows established style and conventions
