### PR TITLE
NGWPC-6073: Add VPU subsetting into icefabric CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,6 +208,7 @@ tests/data/topo_tifs
 
 # all data files
 data
+*.gpkg
 
 # R code
 .Rproj.user

--- a/src/icefabric/cli/hydrofabric.py
+++ b/src/icefabric/cli/hydrofabric.py
@@ -8,7 +8,7 @@ import geopandas as gpd
 from icefabric.builds.graph_connectivity import load_upstream_json
 from icefabric.cli import get_catalog
 from icefabric.helpers import load_creds
-from icefabric.hydrofabric.subset import subset_hydrofabric
+from icefabric.hydrofabric.subset import subset_hydrofabric, subset_hydrofabric_vpu
 from icefabric.schemas.hydrofabric import HydrofabricDomains, IdType
 
 load_creds(dir=Path(__file__).parents[3])
@@ -72,14 +72,23 @@ def subset(
 
     layers_list = list(layers) if layers else ["divides", "flowpaths", "network", "nexus"]
 
-    output_layers = subset_hydrofabric(
-        catalog=_catalog,
-        identifier=identifier,
-        id_type=id_type_enum,
-        layers=layers_list,
-        namespace=domain,
-        graph=connectivity_graphs[domain],
-    )
+    if id_type_enum == IdType.VPU_ID:
+        output_layers = subset_hydrofabric_vpu(
+            catalog=_catalog,
+            layers=layers_list,
+            namespace=domain,
+            vpu_id=identifier,
+        )
+
+    else:
+        output_layers = subset_hydrofabric(
+            catalog=_catalog,
+            identifier=identifier,
+            id_type=id_type_enum,
+            layers=layers_list,
+            namespace=domain,
+            graph=connectivity_graphs[domain],
+        )
 
     output_file.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/icefabric/modules/create_ipes.py
+++ b/src/icefabric/modules/create_ipes.py
@@ -223,7 +223,7 @@ def get_smp_parameters(
         the hydrofabric namespace
     identifier : str
         the gauge identifier
-    module : str, optional
+    extra_module : str, optional
         A setting to determine if a module should be specified to obtain additional SMP parameters.
         Available modules declared for addt'l SMP parameters: 'CFE-S', 'CFE-X', 'LASAM', 'TopModel'
 

--- a/src/icefabric/schemas/hydrofabric.py
+++ b/src/icefabric/schemas/hydrofabric.py
@@ -22,6 +22,7 @@ class IdType(str, Enum):
     HF_ID = "hf_id"
     ID = "id"
     POI_ID = "poi_id"
+    VPU_ID = "vpu_id"
 
 
 class HydrofabricDomains(str, Enum):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ Unified Mock PyIceberg Catalog Test Suite for Hydrofabric v2.2 Data using Rustwo
 
 # Load the sample graph from the actual graph file
 SAMPLE_GRAPH: rx.PyDiGraph = rx.from_node_link_json_file(
-    str(Path(__file__).parent / "data/hi_hf_graph_network.json"),
+    str(Path(__file__).parents[1] / "data/hi_hf_graph_network.json"),
     edge_attrs=read_edge_attrs,
     node_attrs=read_node_attrs,
 )  # type: ignore

--- a/tests/ipes/test_module_ipes.py
+++ b/tests/ipes/test_module_ipes.py
@@ -132,7 +132,7 @@ def test_smp_parameters(mock_catalog, sample_graph, test_identifiers, module_typ
             catalog,
             namespace,
             identifier,
-            module=module_type,
+            extra_module=module_type,
             graph=sample_graph,
         )
 


### PR DESCRIPTION
## Issue Addressed

NGWPC-6073: Add VPU subsetting into icefabric CLI


## Description

adds VPU subsetting to hydrofabric subsetter
to run:
`icefabric subset --catalog sql --identifier 01  --id-type vpu_id --domain conus_hf -o ./data/vpu01.gpkg --layers lakes --layers flowpaths --layers network --layers nexus --layers pois --layers hydrolocations --layers flowpath-attributes-ml --layers flowpath-attributes --layers divide-attributes  --layers divides`

compared all VPUs with lynker 2.2 next gen hydrofabric
- NGWPC has additional POIs in nexus table
- one missing nexus in VPU07  nex-1102857 but it isn't in the icefabric table so not artifact of code
- one dif in divide attributes vpu 02 - 1e5 catchment issue (fixed in ours)

Note: The subetting for other IDs uses a filter to get valid divide_ids, but this was excluded here because it excludes rows with null hf_id. `idx` and `cdx` nexus have null `hf_id`. To include them, this filter is removed in this implementation

also patches tests for ipe modules

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code cleanup/refactor
- [ ] Documentation update

Other (please specify):

## Checklist

- [x] Branch is up to date with master
- [x] Updated tests or added new tests
- [x] Tests & pre-commit hooks pass
- [ ] Updated documentation (if applicable)
- [ ] Code follows established style and conventions
